### PR TITLE
Rbac summary

### DIFF
--- a/rctab_cli/sub_apps/sub.py
+++ b/rctab_cli/sub_apps/sub.py
@@ -329,6 +329,9 @@ def allocations(
 @subscription_app.command()
 def summary(
     subscription_id: Optional[UUID] = typer.Option(None, help="Subscription id"),
+    show_rbac: bool = typer.Option(
+        False, "--show-rbac", help="Include the role assignments"
+    ),
 ) -> None:
     """Get a summary of approvals, allocations and costs for one or all subscriptions."""
     path = "accounting/subscription"
@@ -346,7 +349,13 @@ def summary(
     )
 
     raise_for_status(resp)
-    typer.echo(json.dumps(resp.json(), indent=4, sort_keys=True))
+
+    summaries = resp.json()
+    if not show_rbac:
+        for item in summaries:
+            item.pop("role_assignments")
+
+    typer.echo(json.dumps(summaries, indent=4, sort_keys=True))
 
 
 @finance_app.command("create")

--- a/tests/sub_apps/test_sub.py
+++ b/tests/sub_apps/test_sub.py
@@ -11,8 +11,8 @@ from tests.utils import ExitCodeException
 runner = CliRunner()
 
 
-def test_create() -> None:
-    """Test create command with all commandline options."""
+def test_add() -> None:
+    """Test add command with all commandline options."""
 
     with patch("rctab_cli.sub_apps.sub.add_subscription") as mock_sub, patch(
         "rctab_cli.sub_apps.sub.set_the_persistence"
@@ -42,8 +42,8 @@ def test_create() -> None:
         )
 
 
-def test_create_defaults() -> None:
-    """Test create command with minimal commandline options."""
+def test_add_defaults() -> None:
+    """Test add command with minimal commandline options."""
 
     with patch("rctab_cli.sub_apps.sub.add_subscription") as mock_sub, patch(
         "rctab_cli.sub_apps.sub.set_the_persistence"


### PR DESCRIPTION
## Summary
<!-- What does your PR do? -->
Suppresses printing the role assignments by default when using the `sub summary` command.

The RBAC list can be quite long for some subscriptions so it is better to have it as an option that is disabled by default.

## Issues
<!--List issues this closes -->

## Reviewer
<!-- List anything you would like the reviewer to focus on. -->

## How to run
<!-- Explain how the reviewer should run the code. -->
`rctab sub summary --subscription-id x-y-z`
`rctab sub summary --show-rbac --subscription-id x-y-z`