### PR TITLE
Support zero amounts and priority with finance update

### DIFF
--- a/rctab_cli/sub_apps/sub.py
+++ b/rctab_cli/sub_apps/sub.py
@@ -486,12 +486,14 @@ def finance_update(
         date_to_date = date(date_to_date.year, date_to_date.month, month_range[1])
         new_finance["date_to"] = date_to_date.isoformat()
 
-    new_finance["amount"] = amount if amount else old_finance["amount"]
+    new_finance["amount"] = amount if amount is not None else old_finance["amount"]
     new_finance["finance_code"] = (
         finance_code if finance_code else old_finance["finance_code"]
     )
     new_finance["ticket"] = ticket if ticket else old_finance["ticket"]
-    new_finance["priority"] = priority if priority else old_finance["priority"]
+    new_finance["priority"] = (
+        priority if priority is not None else old_finance["priority"]
+    )
 
     if new_finance == old_finance:
         typer.echo("Finance records identical. Taking no action.")


### PR DESCRIPTION
## Summary
<!-- What does your PR do? -->

The finance update command checks whether a parameter has been passed and only updates the value if it has. With the previous implementation an existence check is made. This masks out None values, but also masks out zero values. In order to support zero values, an explicit check for None is needed.

This changes the check in this way to allow for a zero amount or zero priority to be passed as a parameter.

## Issues
<!--List issues this closes -->

Fixes #24

## Reviewer
<!-- List anything you would like the reviewer to focus on. -->

This change allows zero `priority` and `amount`. But maybe other values (`ticket`?) should have an explicit `None` check as well? I wasn't certain about this.

## How to run
<!-- Explain how the reviewer should run the code. -->

Create a finance row (not on a production system):
```
rctab sub finance create --subscription-id ABC --date-from 2024-12 --date-to 2024-12 --amount 100 --finance-code DEF --ticket GHI --priority 100
```
Get the finance row ID:
```
rctab sub finance list ABC
```
Find the finance row just created and replace the `<FIN_ID>` values below with the value shown in the `finance-id` field.

Update the amount and priority to attempt to set them to zero:
```
rctab sub finance update --finance-id <FIN_ID> --subscription-id ABD --amount 0 --priority 0
```
Check that the `amount` and `priority` are now set to zero:
```
rctab sub finance get --finance_id <FIN_ID>
```