### PR TITLE
Update docs with new poetry env activation

### DIFF
--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -14,7 +14,7 @@ Then from the root of the repository, install dependencies and activate a Poetry
 
 ```bash
 poetry install
-poetry shell
+eval $(poetry env activate)
 ```
 
 You should also install [pre-commit](https://pre-commit.com) and install the pre-commit hooks with


### PR DESCRIPTION
## Summary
<!-- What does your PR do? -->

As of poetry 2.0, using "poetry shell" to activate the environment no longer works without a plugin and the following should be used instead:

eval $(poetry env activate)

This change updates the docs to reflect this.

## Issues
<!--List issues this closes -->

Fixes #30.

## Reviewer
<!-- List anything you would like the reviewer to focus on. -->

## How to run
<!-- Explain how the reviewer should run the code. -->

Build and check the docs (the [developer install](https://rctab.readthedocs.io/projects/rctab-cli/en/latest/content/setup.html) section).